### PR TITLE
Difference between diffent balance methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,23 @@ List<PoloniexChartData> btcDailyChartDataStartingFromYesterday =
 
 ## Trading API Methods (Requires Poloniex account and API access enabled)  
 
-### Return balance
+### Return complete balances
+```java
+String apiKey = "foo";
+String apiSecret = "bar";
+PoloniexExchangeService service = new PoloniexExchangeService(apiKey, apiSecret);
+PoloniexCompleteBalance balances = service.returnBalances(includeZeroBalances = true);
+```
+
+### Return non-zero balances
+```java
+String apiKey = "foo";
+String apiSecret = "bar";
+PoloniexExchangeService service = new PoloniexExchangeService(apiKey, apiSecret);
+PoloniexCompleteBalance balances = service.returnBalances();
+```
+
+### Return balance filtered by currency
 ```java
 String apiKey = "foo";
 String apiSecret = "bar";

--- a/src/main/java/com/cf/ExchangeService.java
+++ b/src/main/java/com/cf/ExchangeService.java
@@ -12,6 +12,7 @@ import com.cf.data.model.poloniex.PoloniexTicker;
 import com.cf.data.model.poloniex.PoloniexTradeHistory;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -33,10 +34,12 @@ public interface ExchangeService
     public List<PoloniexChartData> returnChartData(String currencyPair, Long periodInSeconds, Long startEpochInSeconds);
     
     public PoloniexTicker returnTicker(String currencyName);
-    
+
     public List<String> returnAllMarkets();
 
-    public PoloniexCompleteBalance returnBalance(String currencyName);
+    public Map<String, PoloniexCompleteBalance> returnBalance(boolean includeZeroBalances);
+
+    public PoloniexCompleteBalance returnCurrencyBalance(String currencyName);
 
     public PoloniexFeeInfo returnFeeInfo();
     

--- a/src/main/java/com/cf/client/poloniex/PoloniexExchangeService.java
+++ b/src/main/java/com/cf/client/poloniex/PoloniexExchangeService.java
@@ -16,6 +16,8 @@ import com.cf.data.model.poloniex.PoloniexTradeHistory;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -120,13 +122,44 @@ public class PoloniexExchangeService implements ExchangeService
 
     /**
      * *
+     * Returns the complete balances inclusive non-zero balances or not depending on parameter includeZeroBalances
+     * @param includeZeroBalances The includeZeroBalances
+     * @return Map<String, PoloniexCompleteBalance>
+     */
+    @Override
+    public Map<String, PoloniexCompleteBalance> returnBalance(boolean includeZeroBalances)
+    {
+        long start = System.currentTimeMillis();
+        Map<String, PoloniexCompleteBalance> balance = null;
+        try
+        {
+            String completeBalancesResult = tradingClient.returnCompleteBalances();
+            if (includeZeroBalances) {
+                balance = mapper.mapCompleteBalanceResult(completeBalancesResult);
+            } else {
+                balance = mapper.mapCompleteBalanceResultForNonZeroCurrencies(completeBalancesResult);
+                LOG.trace("Retrieved and mapped complete balance in {} ms", System.currentTimeMillis() - start);
+            }
+            balance = mapper.mapCompleteBalanceResult(completeBalancesResult);
+
+        }
+        catch (Exception ex)
+        {
+            LOG.error("Error retrieving complete balance - {}", ex.getMessage());
+        }
+
+        return balance;
+    }
+
+    /**
+     * *
      * Returns the balance for specified currency type
      *
      * @param currencyType Examples: BTC, ETH, DASH
      * @return PoloniexCompleteBalance
      */
     @Override
-    public PoloniexCompleteBalance returnBalance(String currencyType)
+    public PoloniexCompleteBalance returnCurrencyBalance(String currencyType)
     {
         long start = System.currentTimeMillis();
         PoloniexCompleteBalance balance = null;


### PR DESCRIPTION
Hey, I added two futher method to check the balance of a user and changed the semantics of the exisiting one.

~* `returnBalances` returns all balances~
~* `returnNonZeroBalances` returns all balances with a btc value unequal
to `0.00000000`~
~* `returnCurrencyBalance` return balance of a given currency~

`returnCurrencyBalance` return balance of a given currency

`returnBalance` return all balance
* inclusive coins with a bitcoin value of zero if `includeZeroBalances` is true
* with a btc value unequal to zero if `includeZeroBalances` is false

What do you think?